### PR TITLE
Issue 180: remove potentially large /tmp files

### DIFF
--- a/R/get-functions.R
+++ b/R/get-functions.R
@@ -181,7 +181,8 @@ get_odt <- function(path, source, ...) {
 	
 	txt <- txt[!grepl("^\\s*$", txt)] # Remove text which is just whitespace
 	txt <- paste0(txt, collapse = "\n")
-	
+
+	unlink(path, recursive = TRUE)
 	data.frame(text = txt, stringsAsFactors = FALSE)
 }
 
@@ -198,6 +199,7 @@ get_docx <- function(path, source, ...) {
     txt <- txt[!grepl("^\\s*$", txt)] # Remove text which is just whitespace
     txt <- paste0(txt, collapse = "\n")
 
+    unlink(path, recursive = TRUE)
     data.frame(text = txt, stringsAsFactors = FALSE)
 }
 


### PR DESCRIPTION
Ref: Issue 180. When an odt or docx file is retrieved and processed using get_docx() or get_odt(), a potentially large file is written to /tmp.  This patch proposed removing those /tmp files prior to returning the text contained within them.